### PR TITLE
fix: remove outer parent div and ensure the jsx isn't wrapped with a parent div when only one row

### DIFF
--- a/src/parser/hooks.tsx
+++ b/src/parser/hooks.tsx
@@ -39,16 +39,8 @@ export const useExcalidrawElementsToJSX = () => {
 
     return {
       jsx: (
-        <div
-          style={{
-            width: "100%",
-            height: "100%",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-          }}
-        >
-          <div style={frameStyle}>{jsxElements}</div>
+        <div id={`frame-${frameNode.id}`} style={frameStyle}>
+          {jsxElements}
         </div>
       ),
       error: null,
@@ -143,8 +135,9 @@ export const processRows = (
         rowJSXElements.push(jsxElement);
       }
     }
-
-    if (rowJSXElements.length > 0) {
+    if (rows.length === 1) {
+      jsxElements.push(rowJSXElements);
+    } else if (rowJSXElements.length > 0) {
       const prevRow = index === 0 ? null : rows[index - 1];
       const boundingBoxPrevRow = computeRowBoundingBox(prevRow);
       const boundingBoxCurrentRow = computeRowBoundingBox(row);


### PR DESCRIPTION
closes #2 

Before
<img width="3346" height="1440" alt="Screenshot 2025-10-11 at 1 41 14 PM" src="https://github.com/user-attachments/assets/c9d1e96f-95a3-411f-bd78-6ad42bb2e5d8" />

Now

<img width="3378" height="1496" alt="Screenshot 2025-10-11 at 1 42 15 PM" src="https://github.com/user-attachments/assets/47e0e823-b553-4748-97d6-b5cfd3c9df27" />
