### PR TITLE
feat-responsive

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,7 @@ function App() {
     isDragging.current = true;
   };
 
-  const handleMouseMove = (e: any) => {
+  const handleMouseMove = (e) => {
     if (!isDragging.current || !containerRef.current) return;
 
     const containerRect = containerRef.current.getBoundingClientRect();
@@ -92,7 +92,7 @@ function App() {
         <div
           className={`flex flex-col bg-white border-r border-gray-200 transition-all duration-100`}
           style={{
-            width: showExcaliReactPanel ? `${dividerPosition}%` : "w-full",
+            width: showExcaliReactPanel ? `${dividerPosition}%` : "100%",
           }}
         >
           <div className="bg-gray-50 border-b border-gray-200 px-6 py-4 flex justify-between items-center">
@@ -125,36 +125,37 @@ function App() {
         />
         {showExcaliReactPanel && (
           <>
-            <div style={{ width: `${100 - dividerPosition}%` }}>
-              <div className="flex flex-col bg-white border-r border-gray-200">
-                <div className="bg-gray-50 border-b border-gray-200 px-6 py-4 flex justify-between items-center">
-                  <h2 className="text-l font-semibold text-gray-700">
-                    ExcaliReact App
-                  </h2>
-                  <div className="flex items-center gap-2">
-                    <button
-                      className="bg-white hover:bg-gray-100 text-black px-3 py-1 rounded-md text-xs flex items-center gap-1 border border-gray-300 shadow-sm"
-                      onClick={() => setShowCodePanel(!showCodePanel)}
-                    >
-                      <div className="flex items-center gap-2">
-                        {showCodePanel ? (
-                          <>
-                            <PreviewIcon />
-                            Preview
-                          </>
-                        ) : (
-                          <>
-                            <CodeIcon />
-                            Code
-                          </>
-                        )}
-                      </div>
-                    </button>
-                  </div>
+            <div
+              className="flex flex-col bg-white border-r border-gray-200"
+              style={{ width: `${100 - dividerPosition}%` }}
+            >
+              <div className="bg-gray-50 border-b border-gray-200 px-6 py-4 flex justify-between items-center">
+                <h2 className="text-l font-semibold text-gray-700">
+                  ExcaliReact App
+                </h2>
+                <div className="flex items-center gap-2">
+                  <button
+                    className="bg-white hover:bg-gray-100 text-black px-3 py-1 rounded-md text-xs flex items-center gap-1 border border-gray-300 shadow-sm"
+                    onClick={() => setShowCodePanel(!showCodePanel)}
+                  >
+                    <div className="flex items-center gap-2">
+                      {showCodePanel ? (
+                        <>
+                          <PreviewIcon />
+                          Preview
+                        </>
+                      ) : (
+                        <>
+                          <CodeIcon />
+                          Code
+                        </>
+                      )}
+                    </div>
+                  </button>
                 </div>
-                <div className="flex flex-1 items-center justify-center overflow-auto p-4 relative ">
-                  {showCodePanel ? <CodeEditor /> : <CodePreview />}
-                </div>
+              </div>
+              <div className="flex flex-1 items-center justify-center overflow-auto p-4 relative ">
+                {showCodePanel ? <CodeEditor /> : <CodePreview />}
               </div>
             </div>
           </>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,7 @@ function App() {
     isDragging.current = true;
   };
 
-  const handleMouseMove = (e: MouseEvent) => {
+  const handleMouseMove = (e:  React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     if (!isDragging.current || !containerRef.current) return;
 
     const containerRect = containerRef.current.getBoundingClientRect();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -53,7 +53,7 @@ function App() {
     isDragging.current = true;
   };
 
-  const handleMouseMove = (e) => {
+  const handleMouseMove = (e: MouseEvent) => {
     if (!isDragging.current || !containerRef.current) return;
 
     const containerRect = containerRef.current.getBoundingClientRect();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,10 +21,14 @@ function App() {
   const [showCodePanel, setShowCodePanel] = useState<boolean>(false);
   const [showExcaliReactPanel, setShowExcaliReactPanel] =
     useState<boolean>(true);
+  const [dividerPosition, setDividerPosition] = useState<number>(50); // percentage
 
   const { excalidrawAPI } = useExcalidraw();
 
-  const prevShowExcaliReactPanelRef = useRef<boolean>(null);
+  const prevShowExcaliReactPanelRef = useRef<boolean | null>(null);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isDragging = useRef<boolean>(false);
 
   const handlePreviewPanel = () => {
     prevShowExcaliReactPanelRef.current = showExcaliReactPanel;
@@ -44,6 +48,26 @@ function App() {
       }, 0);
     }
   }, [excalidrawAPI, showExcaliReactPanel]);
+  // Divider logic
+  const handleMouseDown = () => {
+    isDragging.current = true;
+  };
+
+  const handleMouseMove = (e: any) => {
+    if (!isDragging.current || !containerRef.current) return;
+
+    const containerRect = containerRef.current.getBoundingClientRect();
+    const newDividerPosition =
+      ((e.clientX - containerRect.left) / containerRect.width) * 100;
+
+    if (newDividerPosition > 10 && newDividerPosition < 90) {
+      setDividerPosition(newDividerPosition);
+    }
+  };
+
+  const handleMouseUp = () => {
+    isDragging.current = false;
+  };
   return (
     <div className="h-screen flex flex-col bg-gray-50">
       <ExperimentalBanner />
@@ -57,11 +81,19 @@ function App() {
           </span>
         </h1>
       </header>
-      <div className="flex-1 flex">
+      <div
+        // className="flex-1 flex"
+        ref={containerRef}
+        className="flex-1 flex overflow-hidden select-none"
+        onMouseMove={handleMouseMove}
+        onMouseUp={handleMouseUp}
+        onMouseLeave={handleMouseUp}
+      >
         <div
-          className={`flex flex-col bg-white border-r border-gray-200 ${
-            showExcaliReactPanel ? "w-1/2" : "w-full"
-          }`}
+          className={`flex flex-col bg-white border-r border-gray-200 transition-all duration-100`}
+          style={{
+            width: showExcaliReactPanel ? `${dividerPosition}%` : "w-full",
+          }}
         >
           <div className="bg-gray-50 border-b border-gray-200 px-6 py-4 flex justify-between items-center">
             <h2 className="text-l font-semibold text-gray-700">
@@ -87,36 +119,42 @@ function App() {
             <ExcalidrawWrapper />
           </div>
         </div>
+        <div
+          onMouseDown={handleMouseDown}
+          className="w-1 bg-gray-400 cursor-col-resize hover:bg-gray-600 transition-colors"
+        />
         {showExcaliReactPanel && (
           <>
-            <div className="w-1/2 flex flex-col bg-white border-r border-gray-200">
-              <div className="bg-gray-50 border-b border-gray-200 px-6 py-4 flex justify-between items-center">
-                <h2 className="text-l font-semibold text-gray-700">
-                  ExcaliReact App
-                </h2>
-                <div className="flex items-center gap-2">
-                  <button
-                    className="bg-white hover:bg-gray-100 text-black px-3 py-1 rounded-md text-xs flex items-center gap-1 border border-gray-300 shadow-sm"
-                    onClick={() => setShowCodePanel(!showCodePanel)}
-                  >
-                    <div className="flex items-center gap-2">
-                      {showCodePanel ? (
-                        <>
-                          <PreviewIcon />
-                          Preview
-                        </>
-                      ) : (
-                        <>
-                          <CodeIcon />
-                          Code
-                        </>
-                      )}
-                    </div>
-                  </button>
+            <div style={{ width: `${100 - dividerPosition}%` }}>
+              <div className="flex flex-col bg-white border-r border-gray-200">
+                <div className="bg-gray-50 border-b border-gray-200 px-6 py-4 flex justify-between items-center">
+                  <h2 className="text-l font-semibold text-gray-700">
+                    ExcaliReact App
+                  </h2>
+                  <div className="flex items-center gap-2">
+                    <button
+                      className="bg-white hover:bg-gray-100 text-black px-3 py-1 rounded-md text-xs flex items-center gap-1 border border-gray-300 shadow-sm"
+                      onClick={() => setShowCodePanel(!showCodePanel)}
+                    >
+                      <div className="flex items-center gap-2">
+                        {showCodePanel ? (
+                          <>
+                            <PreviewIcon />
+                            Preview
+                          </>
+                        ) : (
+                          <>
+                            <CodeIcon />
+                            Code
+                          </>
+                        )}
+                      </div>
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div className="flex flex-1 items-center justify-center overflow-auto p-4 relative ">
-                {showCodePanel ? <CodeEditor /> : <CodePreview />}
+                <div className="flex flex-1 items-center justify-center overflow-auto p-4 relative ">
+                  {showCodePanel ? <CodeEditor /> : <CodePreview />}
+                </div>
               </div>
             </div>
           </>

--- a/src/UIElementsDropdown.tsx
+++ b/src/UIElementsDropdown.tsx
@@ -67,7 +67,7 @@ export const UIElementsDropdown = ({
         UI Elements
       </button>
       {showUiElements && (
-        <div className="absolute bottom-full left-0 mt-2 w-48 bg-white rounded-md shadow-sm bg-gray-50">
+        <div className="absolute bottom-full left-0 mt-2 w-48 rounded-md shadow-sm bg-gray-50">
           {UIElements.map((uiElement) => (
             <button
               key={uiElement.value}


### PR DESCRIPTION

<img width="1919" height="862" alt="Screenshot 2025-10-13 151052" src="https://github.com/user-attachments/assets/e1e2f9a6-9f07-4304-b60f-085bca4c054c" />

<img width="1898" height="831" alt="Screenshot 2025-10-13 151109" src="https://github.com/user-attachments/assets/0a5d94c6-6d6b-4207-a87a-3a22d0983ba3" />
This pull request introduces a draggable divider between the two main panels in the `App` component, allowing users to dynamically adjust the width of each panel. The implementation includes new state management for the divider position, event handlers for mouse interactions, and updates to the layout and styling to support the resizing functionality.

**Panel resizing functionality:**

* Added `dividerPosition` state and supporting refs (`containerRef`, `isDragging`) to manage the divider and enable resizing between panels.
* Implemented mouse event handlers (`handleMouseDown`, `handleMouseMove`, `handleMouseUp`) to track dragging and update the divider position in real-time.

**Layout and styling updates:**

* Updated the main container to use `ref={containerRef}` and added mouse event listeners for resizing. The left and right panels now use dynamic `width` styles based on `dividerPosition`, replacing fixed width classes. [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L60-R96) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2R122-R131)
* Introduced a draggable divider element with appropriate styling and interaction cues (`cursor-col-resize`, hover effects).