### PR TITLE
fix: Support dotted and dashed border styles in generated React components

### DIFF
--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -38,7 +38,7 @@ export const computeExcalidrawElementStyle = (
     width: element.width,
     height: element.height,
     backgroundColor: element.backgroundColor,
-    border: `${element.strokeWidth}px solid ${element.strokeColor}`,
+    border: `${element.strokeWidth}px ${element.strokeStyle} ${element.strokeColor}`,
     borderRadius,
   };
   switch (element.type) {


### PR DESCRIPTION
### Problem
Border styles (dotted, dashed) set in Excalidraw were not being applied to generated React components. All borders were hardcoded as `solid` regardless of the stroke style selected in the canvas.

### Issue
Issue link - https://github.com/ad1992/ExcaliReact/issues/10

### Solution
Updated `computeExcalidrawElementStyle` to use the element's `strokeStyle` property directly instead of hardcoding `solid`.

**Before:**
`border: `${element.strokeWidth}px solid ${element.strokeColor}`

### Screenshot
<img width="1307" height="778" alt="image" src="https://github.com/user-attachments/assets/67b55088-1345-4d7a-8041-c43c28f0b959" />


