### PR TITLE
fix: opacity change in the generated components

### DIFF
--- a/src/parser/utils.ts
+++ b/src/parser/utils.ts
@@ -39,6 +39,7 @@ export const computeExcalidrawElementStyle = (
     height: element.height,
     backgroundColor: element.backgroundColor,
     border: `${element.strokeWidth}px ${element.strokeStyle} ${element.strokeColor}`,
+    opacity: `${element.opacity / 100}`,
     borderRadius,
   };
   switch (element.type) {


### PR DESCRIPTION
## Description

Background opacity were not being applied to generated React components. 

### Fixed Issue
#12 

### Changes
Added **opacity** style in  **computeExcalidrawElementStyle** from ``parser.ts``  to apply the opaciy value to the generated elements.

## Preview
#### Opacity of 60 is applied on generated components.

<img width="1857" height="720" alt="Screenshot 2025-11-03 122549" src="https://github.com/user-attachments/assets/83d9a095-b4c8-4ffd-beaa-4c28a1eae6cc" />


